### PR TITLE
Add lint/format tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,21 @@ make run-frontend
 The backend server runs on port 8000 and the frontend development server runs on port 5173. The frontend Vite server proxies API requests to the backend on port 8000.
 
 Visit <http://localhost:5173> to view the application.
+
+## Linting and formatting
+
+For the backend Python code run:
+
+```bash
+cd backend
+black .
+ruff .
+```
+
+For the frontend run:
+
+```bash
+cd frontend
+yarn lint
+yarn format
+```

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,3 +8,15 @@ dependencies = [
     "fastapi>=0.115.8",
     "uvicorn>=0.34.0",
 ]
+
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 88
+extend-exclude = [
+    "venv",
+    ".venv",
+    "databutton_app",
+]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,5 @@ openai
 beautifulsoup4
 requests
 supabase
+black==25.1.0
+ruff==0.11.10

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint', 'react', 'react-hooks'],
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+  ],
+  settings: {
+    react: { version: 'detect' },
+  },
+};

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all"
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,md}\"",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -327,6 +328,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
+    "@firebase/app": "^0.11.1",
     "@sentry/react": "7.101.1",
     "@sentry/types": "7.101.1",
     "@types/amplitude-js": "^8",
@@ -353,15 +355,20 @@
     "@types/reveal.js": "^5",
     "@types/three": "^0",
     "@types/vinyl-fs": "^3",
+    "@typescript-eslint/eslint-plugin": "^7.8.0",
+    "@typescript-eslint/parser": "^7.8.0",
+    "@vitejs/plugin-react": "^4.0.0",
     "@vitejs/plugin-react-swc": "3.3.2",
     "autoprefixer": "^10.4.20",
     "dotenv": "16.4.5",
     "eslint": "8.45.0",
+    "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-react-refresh": "0.4.3",
     "openapi-types": "12.1.3",
     "postcss": "^8.4.45",
+    "prettier": "^3.2.5",
     "raw-body": "2.5.2",
     "tailwindcss": "^3.4.10",
     "ts-prune": "0.10.3",
@@ -369,9 +376,7 @@
     "typescript": "5.2.2",
     "typescript-language-server": "4.3.2",
     "vite": "4.4.5",
-    "vite-tsconfig-paths": "4.2.2",
-    "@vitejs/plugin-react": "^4.0.0",
-    "@firebase/app": "^0.11.1"
+    "vite-tsconfig-paths": "4.2.2"
   },
   "packageManager": "yarn@4.0.2",
   "nodeLinker": "pnpm"


### PR DESCRIPTION
## Summary
- configure `black` and `ruff` for backend
- add ESLint and Prettier config for frontend
- document linting instructions in README

## Testing
- `black backend`
- `ruff check backend`
- `yarn install`
- `yarn format`
- `yarn lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684407fd5f90832396908e50b7b59be0